### PR TITLE
resolved missing syslog_drain causing failure stream logs

### DIFF
--- a/src/main/resources/ih-cassandra-service-broker-metadata.json
+++ b/src/main/resources/ih-cassandra-service-broker-metadata.json
@@ -3,6 +3,7 @@
      "name":"ih-cassandra",
      "description":"Cassandra cluster by Ippon Hosting. Only for testing.",
      "bindable":true,
+     "requires":["syslog_drain"],
      "tags":[
        "cassandra",
        "nosql",


### PR DESCRIPTION
Broker unable to stream logs causing this error on push:

```
Error: Server error, status code: 502, error code: 10001, message: The service is attempting to stream logs from your application, but is not registered as a logging service. Please contact the service provider.
```
